### PR TITLE
Correct typo in dates.py

### DIFF
--- a/semantic/dates.py
+++ b/semantic/dates.py
@@ -402,7 +402,7 @@ class DateService(object):
         def sameDay(d1, d2):
             d = d1.day == d2.day
             m = d1.month == d2.month
-            y = d1.year == d2.yaer
+            y = d1.year == d2.year
             return d and m and y
 
         tom = self.now + datetime.timedelta(days=1)


### PR DESCRIPTION
Traceback (most recent call last):
  File "date_example.py", line 10, in <module>
    day = service.convertDay(now, weekday=True)
  File "/usr/local/lib/python2.7/dist-packages/semantic/dates.py", line 410, in convertDay
    if sameDay(day, self.now):
  File "/usr/local/lib/python2.7/dist-packages/semantic/dates.py", line 405, in sameDay
    y = d1.year == d2.yaer
AttributeError: 'datetime.datetime' object has no attribute 'yaer'